### PR TITLE
bugfix: dim on secondary displays

### DIFF
--- a/Clocker/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Clocker/Preferences/Menu Bar/StatusItemHandler.swift
@@ -19,6 +19,7 @@ class StatusItemHandler: NSObject {
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem.button?.toolTip = "Clocker"
         (statusItem.button?.cell as? NSButtonCell)?.highlightsBy = NSCell.StyleMask(rawValue: 0)
+        statusItem.button?.image = NSImage()
         return statusItem
     }()
     


### PR DESCRIPTION
This PR fixes the issue with the dimming on non active secondary displays.

![dim-fix](https://github.com/user-attachments/assets/f2a157c9-cca6-4149-be5b-e4d9909f2fd0)

I love the app, I use it all the time, I would really appreciate it if you could merge this change and deploy a new version to the App Store.

The issue is that when clocker is visible on a display that is not currently active then clocker is so much brighter than the other menubar items. I kind of learned to ignore it but I recently came across this same issue in a [personal project](https://github.com/kmikiy/SpotMenu) and this hack fixes the issue.